### PR TITLE
Add ijson.yajl2_c backend to benchmark

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -28,6 +28,7 @@ import time
 import ijson.backends.python as ijson_python
 import ijson.backends.yajl2 as ijson_yajl2
 import ijson.backends.yajl2_cffi as ijson_yajl2_cffi
+import ijson.backends.yajl2_c as ijson_yajl2_c
 
 from jsonslicer import JsonSlicer
 
@@ -106,6 +107,12 @@ if __name__ == '__main__':
         gen = io.StringIO(jsondata)
         parser = JsonSlicer(gen, ('level1', 'level2', None), path_mode='full')
         for n, (*path, item) in enumerate(parser):
+            assert(item['id'] == n)
+
+    with TestCase('ijson.yajl2_c', 'bytes', args.json_size, results):
+        gen = io.BytesIO(jsondata.encode('utf-8'))
+        parser = ijson_yajl2_c.items(gen, b'level1.level2.item')
+        for n, item in enumerate(parser):
             assert(item['id'] == n)
 
     with TestCase('ijson.yajl2_cffi', 'bytes', args.json_size, results):


### PR DESCRIPTION
On my machine, yajl2_c performance is much closer to JsonSlicer:

```
|                                                 Facility |   Type |   Objects/sec |
|---------------------------------------------------------:|-------:|--------------:|
|                                             json.loads() |    str |       1224.6K |
|                                    json.load(StringIO()) |    str |       1298.0K |
|   **JsonSlicer (no paths, binary input, binary output)** |  bytes |       1106.2K |
|  **JsonSlicer (no paths, unicode input, binary output)** |  bytes |       1089.5K |
|  **JsonSlicer (no paths, binary input, unicode output)** |    str |       1021.1K |
| **JsonSlicer (no paths, unicode input, unicode output)** |    str |       1005.5K |
|               **JsonSlicer (full paths, binary output)** |  bytes |        830.2K |
|              **JsonSlicer (full paths, unicode output)** |    str |        664.6K |
|                                            ijson.yajl2_c |  bytes |        715.0K |
|                                         ijson.yajl2_cffi |  bytes |         89.9K |
|                                              ijson.yajl2 |  bytes |         65.7K |
|                                             ijson.python |    str |         40.2K |
```