### PR TITLE
Update comparison to ijson

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,10 @@ comprehensions or in any place where iterator is accepted.
 The closest competitor is [ijson](https://github.com/isagalaev/ijson),
 and JsonSlicer was written to be better. Namely,
 
-* It's about 15x faster, similar in performance to Python's native `json` module
-* It allows iterating over dictionaries and allows more flexibility when
-  specifying paths/patterns of objects to iterate over
+* It's about 50% faster, similar in performance to Python's native `json` module
+* It allows wildcards when specifying paths/patterns of objects to iterate over
+
+However, it doesn't (yet) have a function to yield an event stream.
 
 The results of bundled benchmark on Python 3.7.2 / clang 6.0.1 / `-O2 -DNDEBUG` / FreeBSD 12.0 amd64 / Core i7-6600U CPU @ 2.60GHz.
 


### PR DESCRIPTION
- Since ijson 2.4, there is a much faster yajl2_c backend
- Since ijson 2.6, there is a kvitems() function to iterate over dicts
- Add main feature that JsonSlicer lacks